### PR TITLE
Serve application using nginx.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 **/__pycache__/
 .idea
 **/*.env
+/backend/staticfiles/

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,5 +1,5 @@
-*.sqlite3
-
+test-db.sqlite3
+*sqlite3
 unit_tests
 test_files
 drscm/tests

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -127,12 +127,9 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.0/howto/static-files/
 
-STATIC_URL = "staticfiles/"
-STATIC_ROOT = BASE_DIR / "staticfiles"
-
-MEDIA_URL = "mediafiles/"
-MEDIA_ROOT = BASE_DIR / "mediafiles"
-
+STATIC_URL = "/static/"
+DEFAULT_STATIC_ROOT = BASE_DIR / "staticfiles"
+STATIC_ROOT = environment('STATIC_ROOT', default=DEFAULT_STATIC_ROOT)
 
 STATICFILES_FINDERS = [
     "django.contrib.staticfiles.finders.FileSystemFinder",

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -129,7 +129,7 @@ USE_TZ = True
 
 STATIC_URL = "/static/"
 DEFAULT_STATIC_ROOT = BASE_DIR / "staticfiles"
-STATIC_ROOT = environment('STATIC_ROOT', default=DEFAULT_STATIC_ROOT)
+STATIC_ROOT = environment("STATIC_ROOT", default=DEFAULT_STATIC_ROOT)
 
 STATICFILES_FINDERS = [
     "django.contrib.staticfiles.finders.FileSystemFinder",

--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -33,14 +33,28 @@ services:
       postgres:
         condition: service_healthy
 
-    ports:
-      - "8000:8000"
-
-    command: ["run", "--debug"]
+    command: ["run"]
+    volumes:
+      - ./staticfiles:/var/www/static
 
     tty: true
-    env_file:
-      - .env
     environment:
+      SECRET_KEY: for-dev-only
+      DEBUG: 0
       PYTHONDONTWRITEBYTECODE: 1
       PYTHONUNBUFFERED: 1
+      DATABASE_URL: postgres://amrouna:mysecretpassword@postgres:5432/webdrscm
+      STATIC_ROOT: /var/www/static
+
+  nginx:
+    logging: *default-logging
+    image: pagespeed/nginx-pagespeed:latest
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/conf.d:/etc/nginx/conf.d
+      - ./staticfiles:/var/www/static
+    depends_on:
+      - api
+volumes:
+  staticfiles:

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -68,7 +68,6 @@ class ApplicationBootstrapper:
             "-w",
             "2",
         ]
-        print("YO")
         # Run gunicorn for the production server.
         gunicorn.app.wsgiapp.run()
 

--- a/backend/nginx/conf.d/local.conf
+++ b/backend/nginx/conf.d/local.conf
@@ -1,0 +1,25 @@
+# first we declare our upstream server, which is our Gunicorn application
+upstream server {
+    # We use api since it's the service name we've chosen in the compose file
+    # Docker will automatically know how to resolve it.
+    server api:8000;
+}
+
+# now we declare our main server
+server {
+
+    listen 80;
+    server_name localhost;
+
+    location / {
+        # everything is passed to Gunicorn
+        proxy_pass http://server;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $host;
+        proxy_redirect off;
+    }
+    location /static/ {
+        autoindex on;
+        alias /var/www/static/;
+    }
+}


### PR DESCRIPTION
This puts nginx in front of the gunicron workers to have a production like setup.

This also delegates the serving of static files to nginx, instead of django.